### PR TITLE
✨ feat(core): allow filter to take category arg

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,8 +24,7 @@ fn main() {
         &config.adjectives_path,
         adjs,
         &config.themes_path,
-        themes
-        // config.themes
+        themes,
     ) {
         Ok(rr) => rr,
         Err(e) => {
@@ -51,10 +50,11 @@ fn main() {
         }
         None => {
             let ramble = rr.randomize(
-                    config.pattern.as_deref(),
-                    config.number,
-                    config.template.as_deref(),
-                    config.verbose >= 1);
+                config.pattern.as_deref(),
+                config.number,
+                config.template.as_deref(),
+                config.verbose >= 1,
+            );
 
             match ramble {
                 Ok(ramble) => {

--- a/core/tests/init.rs
+++ b/core/tests/init.rs
@@ -3,7 +3,7 @@ mod test {
     use std::path::PathBuf;
 
     use maplit::hashmap;
-    use random_ramble::refactor::{RambleKind, RambleValues, RandomRamble};
+    use random_ramble::refactor::{Ramble, RambleKind, RambleMap, RandomRamble};
 
     #[test]
     fn init_default() {
@@ -12,8 +12,7 @@ mod test {
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues::default(),
+                rambles: RambleMap::default(),
                 template: None,
                 context: None,
             }
@@ -22,18 +21,17 @@ mod test {
 
     #[test]
     fn init_with_adjs() {
-        let adjs = vec![
-            "Happy",
-            "Sad"
-        ];
+        let adjs = vec!["Happy", "Sad"];
 
         let rr = RandomRamble::new().with_adjs(adjs);
 
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues(hashmap!{RambleKind::Adjective => vec!["Happy", "Sad"]}),
+                rambles: RambleMap(hashmap! { RambleKind::Adjective => vec![Ramble {
+                    category: None,
+                    values: vec!["Happy", "Sad"]},
+                ]}),
                 template: None,
                 context: None,
             }
@@ -49,10 +47,10 @@ mod test {
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues(hashmap! {
-                    RambleKind::Adjective => vec!["Pretty"],
-                }),
+                rambles: RambleMap(hashmap! { RambleKind::Adjective => vec![Ramble {
+                    category: None,
+                    values: vec!["Pretty"]},
+                ]}),
                 template: None,
                 context: None,
             }
@@ -69,10 +67,10 @@ mod test {
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues(hashmap! {
-                    RambleKind::Adjective => vec!["Kind", "Ruthless"],
-                }),
+                rambles: RambleMap(hashmap! { RambleKind::Adjective => vec![Ramble {
+                    category: None,
+                    values: vec!["Kind", "Ruthless"],
+                }]}),
                 template: None,
                 context: None,
             }
@@ -120,10 +118,10 @@ mod test {
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues(hashmap! {
-                    RambleKind::Theme => vec!["King"],
-                }),
+                rambles: RambleMap(hashmap! { RambleKind::Theme => vec![Ramble {
+                    category: None,
+                    values: vec!["King"]},
+                ]}),
                 template: None,
                 context: None,
             }
@@ -139,15 +137,45 @@ mod test {
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues(hashmap! {
-                    RambleKind::Theme => vec!["Toto"],
-                }),
+                rambles: RambleMap(hashmap! { RambleKind::Theme => vec![Ramble {
+                    category: None,
+                    values: vec!["Toto"]},
+                ]}),
                 template: None,
                 context: None,
             }
         );
     }
+
+    // #[test]
+    // #[should_panic]
+    // fn init_with_themes_from_path() {
+
+    //     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    //     path.push("resources/tests/themes/");
+
+    //     let rr = RandomRamble::new()
+    //         .with_themes_path(&path);
+
+    //     assert_eq!(rr, RandomRamble {
+    //         rambles: vec![],
+    //         _rambles: RambleValues(hashmap! {
+    //             RambleKind::Theme => vec![
+    //                 RambleR {
+    //                     category: Some("test1"),
+    //                     values: vec![ "Toto" ],
+    //                 },
+    //                 RambleR {
+    //                     category: Some("test2"),
+    //                     values: vec![ "Titi" ],
+    //                 }
+    //             ],
+    //         }),
+    //         template: None,
+    //         context: None,
+    //     });
+
+    // }
 
     #[test]
     fn init_with_others() {
@@ -158,10 +186,11 @@ mod test {
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues(hashmap! {
-                    RambleKind::Other("emoji") => vec!["🦀"],
-                }),
+                rambles: RambleMap(hashmap! { RambleKind::Other("emoji") => vec![Ramble {
+                    category: None,
+                    values: vec!["🦀"],
+                },
+                ]}),
                 template: None,
                 context: None,
             }
@@ -177,48 +206,16 @@ mod test {
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues(hashmap! {
-                    RambleKind::Other("emoji") => vec!["🦀"],
-                }),
+                rambles: RambleMap(hashmap! { RambleKind::Other("emoji") => vec![Ramble {
+                    category: None,
+                    values: vec!["🦀"],
+                },
+                ]}),
                 template: None,
                 context: None,
             }
         );
     }
-
-
-    // #[test]
-    // fn init_with_themes_from_path() {
-
-    //     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    //     path.push("resources/tests/themes/");
-
-    //     let rr = RandomRamble::new()
-    //         .with_themes_path(&path);
-
-    //     assert_eq!(rr, RandomRamble {
-    //         rambles: vec![
-    //             Ramble_ {
-    //                 kind: RambleKind::Theme,
-    //                 value: "Titi",
-    //                 file: Some(File {
-    //                     name: "test2",
-    //                     path: format!("{}test2", path.clone().into_os_string().into_string().expect("🤷"))
-    //                 })
-    //             },
-    //             Ramble {
-    //                 kind: RambleKind::Theme,
-    //                 value: "Toto",
-    //                 file: Some(File {
-    //                     name: "test1",
-    //                     path: format!("{}test1", path.clone().into_os_string().into_string().expect("🤷"))
-    //                 })
-    //             },
-    //         ],
-    //         template: None
-    //     });
-    // }
 
     #[test]
     fn init_with_template() {
@@ -227,8 +224,7 @@ mod test {
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: vec![],
-                _rambles: RambleValues::default(),
+                rambles: RambleMap::default(),
                 template: Some("A {{adj}} for {{theme}}"),
                 context: None,
             }

--- a/core/tests/mod.rs
+++ b/core/tests/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use random_ramble::refactor::RandomRamble;
+    use random_ramble::refactor::{Ramble, RambleKind, RandomRamble};
 
     #[test]
     fn template_replace() {
@@ -32,9 +32,7 @@ mod test {
         let adjs = vec!["Clever", "Stupid"];
         let themes = vec!["Titi", "Fifi"];
 
-        let r = RandomRamble::new()
-            .with_adjs(adjs)
-            .with_themes(themes);
+        let r = RandomRamble::new().with_adjs(adjs).with_themes(themes);
 
         // TODO: find better way to test randomness
         println!("{}", r.to_string());
@@ -53,7 +51,66 @@ mod test {
             .with_template("{{ adj | rr }} {{ emoji | rr }}");
 
         // TODO: find better way to test randomness
-        // assert_eq!(r, "Clever 🦀");
+        // assert_eq!(r.to_string(), "Clever 🦀");
         assert_eq!(r.to_string().len(), "Clever 🦀".len());
     }
+
+    #[test]
+    fn template_replace_custom_ramble_vec_with_ramble() {
+        let en = vec!["Clever", "Stupid"];
+
+        let adjs = Ramble { category: Some("en"), values: en };
+
+        let emojis = vec!["🦀", "🐕"];
+
+        let r = RandomRamble::new()
+            .with_ramble(RambleKind::Adjective, adjs)
+            .with_others("emoji", emojis)
+            .with_template("{{ adj | rr }} {{ emoji | rr }}");
+
+        // TODO: find better way to test randomness
+        // assert_eq!(r.to_string(), "Clever 🦀");
+        assert_eq!(r.to_string().len(), "Clever 🦀".len());
+    }
+
+    #[test]
+    fn template_replace_custom_ramble_vec_with_category() {
+        let en = vec!["Clever", "Stupid"];
+
+        let adjs = Ramble { category: Some("en"), values: en };
+
+        let emojis = vec!["🦀", "🐕"];
+
+        let r = RandomRamble::new()
+            .with_ramble(RambleKind::Adjective, adjs)
+            .with_others("emoji", emojis)
+            .with_template("{{ adj | rr(c='en') }} {{ emoji | rr }}");
+
+        // TODO: find better way to test randomness
+        // assert_eq!(r.to_string(), "Clever 🦀");
+        assert_eq!(r.to_string().len(), "Clever 🦀".len());
+    }
+    #[test]
+    fn template_replace_custom_ramble_vec_with_categories() {
+        let en = vec!["Clever", "Stupid"];
+        let fr = vec!["Malin", "Idiot"];
+
+        let en_adjs = Ramble { category: Some("en"), values: en };
+        let fr_adjs = Ramble { category: Some("fr"), values: fr };
+
+        let emojis = vec!["🦀", "🐕"];
+
+        let r = RandomRamble::new()
+            .with_rambles(RambleKind::Adjective, vec![ en_adjs, fr_adjs])
+            .with_others("emoji", emojis)
+            .with_template("{{ adj | rr(c='fr') }} {{ emoji | rr }}");
+
+        let fr = vec!["Malin", "Idiot"];
+        assert!(fr.iter().any(|&a| a == r.to_string().split(' ').collect::<Vec<&str>>()[0]));
+
+        // TODO: find better way to test randomness
+        // assert_eq!(r.to_string(), "Idiot 🐕");
+        assert_eq!(r.to_string().len(), "Malin 🦀".len());
+    }
+
 }

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,6 @@
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
             # dev
-            lolcat
             rust-analyzer
             cargo-outdated
             # build
@@ -27,13 +26,15 @@
             openssl
             pkgconfig
             rust-linux
+            # random stuff
+            lolcat
+            figlet
           ];
 
-
           shellHook = ''
-            echo "Welcome to ${pname} !" | lolcat
-            [ ! -f ./target/debug/${pname} ] && cargo build ; ln -sf ./target/debug/${pname} rr
-          '';
+              figlet "${pname}" -f $(showfigfonts | rg '(\w+) :' -r '$1' | shuf -n 1) | lolcat
+              [ ! -f ./target/debug/${pname} ] && cargo build ; ln -sf ./target/debug/${pname} rr
+            '';
         };
       });
 }


### PR DESCRIPTION
The Map passed to the filter now takes a `HashMap<RambleKind<'a>,
Vec<Ramble<'a>>>` which contains a field `category` and a vec of values.

The filter itself takes an argument `c`, that allows us to filter result
for a given category.

Here's an example:
```
{{ adj | rr }} {{ theme | rr(c='hero') }}
```

- various refactor