### PR TITLE
🔨 refactor(core): remove enum RambleKind

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -42,8 +42,13 @@ pub struct Config {
     pub adjs: Vec<String>,
 
     /// Provide a template from which to generate words
-    #[clap(short = 'T', long)]
-    pub template: Option<String>,
+    // FIXME: use custom rr filter
+    #[clap(short = 'T', long, default_value = "{{ adj }} {{ theme }}")]
+    pub template: String,
+
+    /// Provide templates from which to generate words
+    #[clap(long, default_value = "{{ adj | rr }} {{ theme | rr }}")]
+    pub templates: Vec<String>,
 
     /// try the refactor version
     #[clap(short, long)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,25 +22,18 @@ fn main() -> Result<(), RambleError> {
     let adjs = config.adjs.iter().map(AsRef::as_ref).collect();
 
     if config.refactor {
-        let template = config
-            .template
-            .unwrap_or_else(|| "{{ adj | rr }} {{ theme | rr }}".to_string());
         let rr = _RandomRamble::new()
-            .with_adjs(adjs)
-            .with_themes(themes)
-            .with_adjs_path(&config.adjectives_path)
+            .with_rambles("adj", adjs)
+            .with_rambles("theme", themes)
+            .with_rambles_path("adj", &config.adjectives_path)
             .expect("no adjs path")
-            .with_themes_path(&config.themes_path)
+            .with_rambles_path("theme", &config.themes_path)
             .expect("no themes path")
-            .with_template(&template)
+            .with_templates(config.templates.iter().map(AsRef::as_ref).collect())
             .build()?;
 
-        if config.number > 1 {
-            for r in rr.take(config.number) {
-                println!("{}", r);
-            }
-        } else {
-            println!("{}", rr.to_string());
+        for r in rr.take(config.number) {
+            println!("{}", r);
         }
     } else {
         let rr = match RandomRamble::new(&config.adjectives_path, adjs, &config.themes_path, themes)
@@ -71,7 +64,7 @@ fn main() -> Result<(), RambleError> {
                 let ramble = rr.randomize(
                     config.pattern.as_deref(),
                     config.number,
-                    config.template.as_deref(),
+                    Some(&config.template),
                     config.verbose >= 1,
                 );
 

--- a/core/tests/init.rs
+++ b/core/tests/init.rs
@@ -24,12 +24,12 @@ mod test {
     fn init_with_adjs() {
         let adjs = vec!["Happy", "Sad"];
 
-        let rr = RandomRamble::new().with_adjs(adjs);
+        let rr = RandomRamble::new().with_rambles("adj", adjs);
 
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: RambleMap(hashmap! { RambleKind::Adjective => vec![Ramble {
+                rambles: RambleMap(hashmap! { RambleKind("adj") => vec![Ramble {
                     category: None,
                     values: vec!["Happy".into(), "Sad".into()]},
                 ]}),
@@ -44,12 +44,12 @@ mod test {
     fn init_with_adj_from_str() {
         let adj = "Pretty";
 
-        let rr: RandomRamble = RandomRamble::default().with_adj(adj);
+        let rr: RandomRamble = RandomRamble::default().with_ramble("adj", adj);
 
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: RambleMap(hashmap! { RambleKind::Adjective => vec![Ramble {
+                rambles: RambleMap(hashmap! { RambleKind("adj") => vec![Ramble {
                     category: None,
                     values: vec!["Pretty".into()]},
                 ]}),
@@ -65,12 +65,12 @@ mod test {
         let adj1 = "Kind";
         let adj2 = "Ruthless";
 
-        let rr = RandomRamble::new().with_adjs(vec![adj1, adj2]);
+        let rr = RandomRamble::new().with_rambles("adj", vec![adj1, adj2]);
 
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: RambleMap(hashmap! { RambleKind::Adjective => vec![Ramble {
+                rambles: RambleMap(hashmap! { RambleKind("adj") => vec![Ramble {
                     category: None,
                     values: vec!["Kind".into(), "Ruthless".into()],
                 }]}),
@@ -88,7 +88,7 @@ mod test {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("nope");
 
-        RandomRamble::new().with_adjs_path(&path).unwrap();
+        RandomRamble::new().with_rambles_path("adj", &path).unwrap();
     }
 
     #[test]
@@ -98,7 +98,7 @@ mod test {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("nope");
 
-        RandomRamble::new().with_adjs_path(&path).unwrap();
+        RandomRamble::new().with_rambles_path("adj", &path).unwrap();
     }
 
     #[test]
@@ -106,14 +106,14 @@ mod test {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("resources/tests/adjectives/pt");
 
-        let rr = match RandomRamble::new().with_adjs_path(&path) {
+        let rr = match RandomRamble::new().with_rambles_path("adj", &path) {
             Ok(rr) => rr,
             Err(e) => {
                 panic!("{} {:#?}", e, e);
             }
         };
 
-        assert!(&rr.rambles.0.eq(&hashmap! { RambleKind::Adjective => vec![
+        assert!(&rr.rambles.0.eq(&hashmap! { RambleKind("adj") => vec![
             Ramble {
                 category: Some("pt".into()),
                 values: vec!["Tímido".into()]
@@ -125,12 +125,12 @@ mod test {
     fn init_with_themes() {
         let themes = vec!["King"];
 
-        let rr = RandomRamble::new().with_themes(themes);
+        let rr = RandomRamble::new().with_rambles("theme", themes);
 
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: RambleMap(hashmap! { RambleKind::Theme => vec![Ramble {
+                rambles: RambleMap(hashmap! { RambleKind("theme") => vec![Ramble {
                     category: None,
                     values: vec!["King".into()]},
                 ]}),
@@ -145,12 +145,12 @@ mod test {
     fn init_with_theme_from_string() {
         let theme = "Toto";
 
-        let rr = RandomRamble::new().with_theme(theme);
+        let rr = RandomRamble::new().with_ramble("theme", theme);
 
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: RambleMap(hashmap! { RambleKind::Theme => vec![Ramble {
+                rambles: RambleMap(hashmap! { RambleKind("theme") => vec![Ramble {
                     category: None,
                     values: vec!["Toto".into()]},
                 ]}),
@@ -166,14 +166,14 @@ mod test {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("resources/tests/themes/country");
 
-        let rr = match RandomRamble::new().with_themes_path(&path) {
+        let rr = match RandomRamble::new().with_rambles_path("theme", &path) {
             Ok(rr) => rr,
             Err(e) => {
                 panic!("{} {:#?}", e, e);
             }
         };
 
-        assert!(&rr.rambles.0.eq(&hashmap! { RambleKind::Theme => vec![
+        assert!(&rr.rambles.0.eq(&hashmap! { RambleKind("theme") => vec![
             Ramble {
                 category: Some("country".into()),
                 values: vec!["Portugal".into()]
@@ -186,7 +186,7 @@ mod test {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("resources/tests/themes/");
 
-        let rr = match RandomRamble::new().with_themes_path(&path) {
+        let rr = match RandomRamble::new().with_rambles_path("theme", &path) {
             Ok(rr) => rr,
             Err(e) => {
                 panic!("{}", e.to_string());
@@ -201,12 +201,12 @@ mod test {
     fn init_with_others() {
         let others = vec!["🦀"];
 
-        let rr = RandomRamble::new().with_others("emoji", others);
+        let rr = RandomRamble::new().with_rambles("emoji", others);
 
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: RambleMap(hashmap! { RambleKind::Other("emoji") => vec![Ramble {
+                rambles: RambleMap(hashmap! { RambleKind("emoji") => vec![Ramble {
                     category: None,
                     values: vec!["🦀".into()],
                 },
@@ -222,12 +222,12 @@ mod test {
     fn init_with_other_from_string() {
         let other = "🦀";
 
-        let rr = RandomRamble::new().with_other("emoji", other);
+        let rr = RandomRamble::new().with_ramble("emoji", other);
 
         assert_eq!(
             rr,
             RandomRamble {
-                rambles: RambleMap(hashmap! { RambleKind::Other("emoji") => vec![Ramble {
+                rambles: RambleMap(hashmap! { RambleKind("emoji") => vec![Ramble {
                     category: None,
                     values: vec!["🦀".into()],
                 },
@@ -244,22 +244,21 @@ mod test {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("resources/tests/others/greetings/fr");
 
-        let rr = match RandomRamble::new().with_others_path("greetings", &path) {
+        let rr = match RandomRamble::new().with_rambles_path("greetings", &path) {
             Ok(rr) => rr,
             Err(e) => {
                 panic!("{} {:#?}", e, e);
             }
         };
 
-        assert!(&rr
-            .rambles
-            .0
-            .eq(&hashmap! { RambleKind::Other("greetings") => vec![
+        assert!(
+            &rr.rambles.0.eq(&hashmap! { RambleKind("greetings") => vec![
                 Ramble {
                     category: Some("fr".into()),
                     values: vec!["Bonjour".into()]
                 },
-            ]}));
+            ]})
+        );
     }
 
     #[test]

--- a/core/tests/mod.rs
+++ b/core/tests/mod.rs
@@ -3,7 +3,7 @@ mod test {
     use std::path::PathBuf;
 
     use pretty_assertions::assert_eq;
-    use random_ramble::refactor::{Ramble, RambleKind, RandomRamble};
+    use random_ramble::refactor::RandomRamble;
 
     #[test]
     fn template_replace() {
@@ -12,8 +12,8 @@ mod test {
 
         let r = RandomRamble::new()
             .with_template("A {{ adj | rr | lower }} {{ theme | rr }}")
-            .with_adj(adj)
-            .with_theme(theme)
+            .with_ramble("adj", adj)
+            .with_ramble("theme", theme)
             .build()
             .expect("we gud");
 
@@ -23,8 +23,8 @@ mod test {
     #[test]
     fn template_replace_empty_map() {
         let r = RandomRamble::new()
-            .with_adjs(vec![])
-            .with_themes(vec![])
+            .with_rambles("adj", vec![])
+            .with_rambles("theme", vec![])
             .with_template("Nothing {{ theme | rr }}to{{ adj | rr }} see here.")
             .build()
             .expect("we gud");
@@ -38,8 +38,8 @@ mod test {
         let theme = "Toto";
 
         let r = RandomRamble::new()
-            .with_adj(adj)
-            .with_theme(theme)
+            .with_ramble("adj", adj)
+            .with_ramble("theme", theme)
             .build()
             .expect("we gud");
 
@@ -52,8 +52,8 @@ mod test {
         let theme = "Toto";
 
         let r = RandomRamble::new()
-            .with_adj(adj)
-            .with_theme(theme)
+            .with_ramble("adj", adj)
+            .with_ramble("theme", theme)
             .build()
             .expect("we gud")
             .take(2);
@@ -69,8 +69,8 @@ mod test {
         let themes = vec!["Titi", "Fifi"];
 
         let r = RandomRamble::new()
-            .with_adjs(adjs)
-            .with_themes(themes)
+            .with_rambles("adj", adjs)
+            .with_rambles("theme", themes)
             .build()
             .expect("we gud");
 
@@ -86,8 +86,8 @@ mod test {
         let emojis = vec!["🦀", "🐕"];
 
         let r = RandomRamble::new()
-            .with_adjs(adjs)
-            .with_others("emoji", emojis)
+            .with_rambles("adj", adjs)
+            .with_rambles("emoji", emojis)
             .with_template("{{ adj | rr }} {{ emoji | rr }}")
             .build()
             .expect("we gud");
@@ -103,8 +103,8 @@ mod test {
         let emojis = vec!["🦀", "🐕", "🐈", "🐖", "🐄"];
 
         let r = RandomRamble::new()
-            .with_adjs(adjs)
-            .with_others("emoji", emojis)
+            .with_rambles("adj", adjs)
+            .with_rambles("emoji", emojis)
             .with_template("{{ adj | rr }} {{ emoji | rr }}")
             .build()
             .expect("we gud")
@@ -112,113 +112,6 @@ mod test {
 
         // TODO: find better way to test randomness
         assert_eq!(r.len(), 15);
-    }
-
-    #[test]
-    fn template_replace_custom_ramble_vec_with_ramble() {
-        let en = vec!["Clever".into(), "Stupid".into()];
-
-        let adjs = Ramble {
-            category: Some("en".into()),
-            values: en,
-        };
-
-        let emojis = vec!["🦀", "🐕"];
-
-        let r = RandomRamble::new()
-            .with_ramble(RambleKind::Adjective, adjs)
-            .with_others("emoji", emojis)
-            .with_template("{{ adj | rr }} {{ emoji | rr }}")
-            .build()
-            .expect("we gud");
-
-        // TODO: find better way to test randomness
-        // assert_eq!(r.to_string(), "Clever 🦀");
-        assert_eq!(r.to_string().len(), "Clever 🦀".len());
-    }
-
-    #[test]
-    fn template_replace_custom_ramble_vec_with_category() {
-        let en = vec!["Clever".into(), "Stupid".into()];
-
-        let adjs = Ramble {
-            category: Some("en".into()),
-            values: en,
-        };
-
-        let emojis = vec!["🦀", "🐕"];
-
-        let r = RandomRamble::new()
-            .with_ramble(RambleKind::Adjective, adjs)
-            .with_others("emoji", emojis)
-            .with_template("{{ adj | rr(c='en') }} {{ emoji | rr }}")
-            .build()
-            .expect("we gud");
-
-        // TODO: find better way to test randomness
-        // assert_eq!(r.to_string(), "Clever 🦀");
-        assert_eq!(r.to_string().len(), "Clever 🦀".len());
-    }
-
-    #[test]
-    fn template_replace_custom_ramble_vec_with_categories() {
-        let en = vec!["Clever".into(), "Stupid".into()];
-        let fr = vec!["Malin".into(), "Idiot".into()];
-
-        let en_adjs = Ramble {
-            category: Some("en".into()),
-            values: en,
-        };
-        let fr_adjs = Ramble {
-            category: Some("fr".into()),
-            values: fr,
-        };
-
-        let emojis = vec!["🦀".into(), "🐕".into()];
-
-        let r = RandomRamble::new()
-            .with_rambles(RambleKind::Adjective, vec![en_adjs, fr_adjs])
-            .with_others("emoji", emojis)
-            .with_template("{{ adj | rr(c='fr') }} {{ emoji | rr }}")
-            .build()
-            .expect("we gud");
-
-        let r = r.to_string();
-        let fr = vec!["Malin", "Idiot"];
-        assert!(fr
-            .iter()
-            .any(|&a| a == r.split(' ').collect::<Vec<&str>>()[0]));
-
-        // TODO: find better way to test randomness
-        // assert_eq!(r.to_string(), "Idiot 🐕");
-        assert_eq!(r.len(), "Malin 🦀".len());
-    }
-
-    #[test]
-    fn template_replace_custom_ramble_vec_with_categories_not_found() {
-        let en = vec!["Clever".into(), "Stupid".into()];
-        let fr = vec!["Malin".into(), "Idiot".into()];
-
-        let en_adjs = Ramble {
-            category: Some("en".into()),
-            values: en,
-        };
-        let fr_adjs = Ramble {
-            category: Some("fr".into()),
-            values: fr,
-        };
-
-        let emojis = vec!["🦀", "🐕"];
-
-        let r = RandomRamble::new()
-            .with_rambles(RambleKind::Adjective, vec![en_adjs, fr_adjs])
-            .with_others("emoji", emojis)
-            .with_template("{{ adj | rr(c='pt') }} {{ emoji | rr }}")
-            .build()
-            .expect("we gud");
-
-        let r = r.to_string();
-        assert_eq!(r, "???");
     }
 
     #[test]
@@ -230,9 +123,9 @@ mod test {
         theme_path.push("resources/tests/themes/");
 
         let rr = RandomRamble::new()
-            .with_adjs_path(&adj_path)
+            .with_rambles_path("adj", &adj_path)
             .expect("adjs not ok")
-            .with_themes_path(&theme_path)
+            .with_rambles_path("theme", &theme_path)
             .expect("themes not ok")
             .with_template("{{ adj | rr(c='en') }} {{ theme | rr(c='toto') }}")
             .build()


### PR DESCRIPTION
`RambleKind` is now a simple struct holding the kind name.

Having an enum with Adjective, Theme and Other didn't realy make sens.
We might as well have just one type and specify the kind when
"registering" it.